### PR TITLE
feat(basket): Add new animation for empty state and smooth layout animation for item deletion

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -6,7 +6,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Vite + React + TS</title>
   </head>
-  <body>
+  <body class="bg-default-bg">
     <div id="root"></div>
     <script type="module" src="/src/main.tsx"></script>
   </body>

--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -16,11 +16,27 @@
     --font-quicksand: Quicksand, "sans-serif";
     --font-jost: Jost, "sans-serif";
     --font-wix-madefor: Wix Madefor, "sans-serif";
-    --color-error-red: #c03d1a;
-    --color-default-bg: #F7F8F4;
-    --color-brand-focus: #8ba888;
-    --color-brand-colour-1: #D0A49E;
-    --color-brand-colour-2: #987998;
+    /* --color-error-red: #c03d1a; */
+    --color-error-red: #d63e20;
+    --color-default-bg: #F3F3F3; /* #F7F8F4; */
+    /* --color-default-bg: #F1F2F4; */
+    --color-brand-focus: #0A65DB;
+    /* --color-brand-colour-1: #b51963; */
+    --color-brand-colour-1: #5CB962;
+    /* --color-brand-colour-2: #624E75; */
+    --color-brand-colour-2: #7B559F;
+    /* --color-brand-colour-3: #f1bdb9; */
+    --color-brand-colour-3: #f2561d;
+    /* --color-brand-colour-4: #e9ecef; */
+    --color-brand-colour-4: #5A92B6;
+    --color-brand-colour-5: #6B8083;
+    --color-unavailable: #DBD9DA;
+    --color-unavailable-text: #59585D;
+    --color-tooltip-bg: #181527; /* Not using at the moment */
+    --color-icon-disabled: #B6C2C4;
+    --color-icon-disabled-bg: #E7E9EC;
+    --color-icon-hover: #ADADAD;
+    --color-icon-pressed: #636172;
 }
 
 .form-error {

--- a/frontend/src/animations/VerticalCutAnimatedText.tsx
+++ b/frontend/src/animations/VerticalCutAnimatedText.tsx
@@ -1,0 +1,87 @@
+import { motion, Variants } from "motion/react";
+
+type AnimationProps = {
+  text: string;
+  splitType?: "letter" | "word";
+  className?: string;
+  staggerFrom?: "first" | "last" | "middle" | "random" | number;
+  playAnimation?: boolean;
+};
+
+const kerningMap: { [key: string]: string } = {
+  Y: "-0.15em",
+  T: "-0.08em",
+  V: "-0.08em",
+  W: "-0.08em",
+  A: "-0.08em",
+};
+
+const containerVariants: Variants = {
+  hidden: {},
+  visible: (i: number = 1) => ({
+    transition: {
+      staggerChildren: i / 2,
+    },
+  }),
+};
+
+const itemVariants: Variants = {
+  hidden: {
+    y: "-100%",
+  },
+  visible: {
+    y: 0,
+    transition: {
+      type: "spring",
+      stiffness: 230,
+      damping: 25,
+      duration: 0.3,
+    },
+  },
+};
+
+export const VerticalCutAnimatedText = ({
+  text,
+  splitType = "letter",
+  className,
+  playAnimation = true,
+}: AnimationProps) => {
+  const splitText = splitType === "word" ? text.split(/(\s+)/) : text.split("");
+  const staggerSpeed = splitType === "word" ? 0.1 : 0.03;
+
+  return (
+    <div className={`relative ${className}`}>
+      <span
+        className={`absolute top-0 ${
+          splitType === "word" ? "left-0" : "left-0.5"
+        } text-transparent`}
+      >
+        {text}
+      </span>
+      <motion.div
+        aria-hidden={true}
+        role="heading"
+        variants={containerVariants}
+        custom={staggerSpeed}
+        initial={playAnimation ? "hidden" : false}
+        animate="visible"
+        className={`select-none`}
+      >
+        {splitText.map((item, index) => {
+          const marginRight = kerningMap[item];
+          return (
+            <div
+              key={`${item}-${index}`}
+              className="overflow-hidden inline-block"
+              style={{ marginRight }}
+            >
+              <motion.span className="inline-block" variants={itemVariants}>
+                {item === " " ? "\u00A0" : item}
+              </motion.span>
+            </div>
+          );
+        })}
+      </motion.div>
+    </div>
+  );
+};

--- a/frontend/src/components/basket/BasketLineItem.tsx
+++ b/frontend/src/components/basket/BasketLineItem.tsx
@@ -25,14 +25,37 @@ const BasketLineItem: React.FC<BasketLineItemProps> = ({ item }) => {
     });
   };
 
+  const EXIT_DURATION = 0.7;
+  const EXIT_DELAY = EXIT_DURATION * 0.7;
+
   return (
-    <motion.div layout className="overflow-hidden w-full">
+    <motion.div
+      layout
+      layoutId={`basket-item-${item.variantId}`}
+      initial={false}
+      exit={{
+        height: 0,
+        marginBottom: 0,
+        paddingTop: 0,
+        paddingBottom: 0,
+        transition: {
+          duration: EXIT_DURATION,
+          ease: easeInOutExpo,
+          delay: EXIT_DELAY,
+        },
+      }}
+      className="overflow-hidden"
+    >
       <motion.div
-        layout
         initial={false}
         exit={{
           y: "-104%",
-          transition: { duration: 0.8, ease: easeInOutExpo },
+          transition: {
+            type: "spring",
+            damping: 50,
+            stiffness: 300,
+            duration: EXIT_DURATION,
+          },
         }}
         role="listitem"
         className={`flex items-center gap-4 p-4 border-b border border-indigo-600`}

--- a/frontend/src/components/ui/MainNav.tsx
+++ b/frontend/src/components/ui/MainNav.tsx
@@ -26,8 +26,8 @@ const MainNav: React.FC = () => {
               to={link}
               className={({ isActive }) =>
                 isActive
-                  ? "underline underline-offset-5"
-                  : `hover:underline underline-offset-5`
+                  ? "underline underline-offset-7 decoration-[3px]"
+                  : `hover:underline underline-offset-5 decoration-[3px]`
               }
               end
               onClick={() => setIsMenuOpen(false)}
@@ -56,7 +56,7 @@ const MainNav: React.FC = () => {
         </nav>
       ) : (
         <>
-          <nav className={`w-screen border-b-1`}>
+          <nav className={`w-full`}>
             {getNavContent(
               "flex flex-row w-fit m-auto gap-10 text-[22px] font-dm-sans font-medium h-[110px]",
               true

--- a/frontend/src/pages/Basket.tsx
+++ b/frontend/src/pages/Basket.tsx
@@ -5,6 +5,7 @@ import BasketFooter from "../components/basket/BasketFooter";
 import { motion, LayoutGroup, AnimatePresence } from "motion/react";
 import { easeInOutExpo } from "../utils/ease";
 import { useEffect, useRef, useState } from "react";
+import { VerticalCutAnimatedText } from "../animations/VerticalCutAnimatedText";
 
 const BasketPage: React.FC = () => {
   const state = useBasketState();
@@ -21,28 +22,52 @@ const BasketPage: React.FC = () => {
     }
   }, [state.items.length]);
 
+  const createContinueShoppingContainer = (
+    emptyBasket: boolean
+  ): React.ReactNode => {
+    return (
+      <motion.div
+        layout="position"
+        initial={emptyBasket && isEmptyThroughDeletion ? { opacity: 0 } : false}
+        animate={{ opacity: 1 }}
+        whileHover={{
+          color: "var(--color-brand-colour-2)",
+          transition: { duration: 0.2 },
+        }}
+        transition={{
+          delay: isEmptyThroughDeletion && !emptyBasket ? 0.2 : 0,
+          ease: easeInOutExpo,
+          duration: 0.6,
+        }}
+        className={`flex place-content-center ${
+          emptyBasket ? "mt-0 text-2xl" : "mt-10"
+        }`}
+      >
+        <Link to="/products">
+          {emptyBasket ? "Have a look at our products" : "Continue shopping"}
+        </Link>
+      </motion.div>
+    );
+  };
+
   return (
     <LayoutGroup>
-      <motion.div layout initial={false} className="min-h-[500px] w-full">
+      <motion.div
+        layout
+        initial={false}
+        className="relative min-h-[500px] w-full"
+      >
         <AnimatePresence mode="wait">
           {state.items.length === 0 ? (
-            <motion.h2
-              key="empty-state"
-              layout="position"
-              className="text-center text-[clamp(4rem,9vw,6rem)] pt-[15vb] font-outfit"
-              initial={isEmptyThroughDeletion ? { opacity: 0 } : false}
-              animate={{
-                opacity: 1,
-                transition: {
-                  duration: 0.8,
-                  ease: easeInOutExpo,
-                  delay: 0.2,
-                },
-              }}
-            >
-              {`Your basket is empty`}
-              <span className="pl-[0.2em] text-nowrap">{`:(`}</span>
-            </motion.h2>
+            <div className="w-screen min-h-[calc((100svh-220px)/2)] flex flex-col items-center justify-end">
+              <VerticalCutAnimatedText
+                text="Your basket is empty :("
+                splitType="word"
+                className="text-[clamp(4rem,9vw,6rem)] font-outfit"
+                playAnimation={isEmptyThroughDeletion}
+              />
+              {createContinueShoppingContainer(true)}
+            </div>
           ) : (
             <motion.div
               key="basket-content"
@@ -56,22 +81,10 @@ const BasketPage: React.FC = () => {
                 ))}
               </AnimatePresence>
               <BasketFooter />
+              {createContinueShoppingContainer(false)}
             </motion.div>
           )}
         </AnimatePresence>
-        <motion.div
-          layout="position"
-          transition={{
-            delay: state.items.length === 0 ? 0.1 : 0,
-            ease: easeInOutExpo,
-            duration: 0.6,
-          }}
-          className={`flex place-content-center pt-10 ${
-            state.items.length > 0 ? "mt-3" : "pt-5 mt-0"
-          }`}
-        >
-          <Link to="/products">Continue shopping</Link>
-        </motion.div>
       </motion.div>
     </LayoutGroup>
   );

--- a/frontend/src/pages/Basket.tsx
+++ b/frontend/src/pages/Basket.tsx
@@ -50,7 +50,7 @@ const BasketPage: React.FC = () => {
               layout="position"
               exit={{ opacity: 0 }}
             >
-              <AnimatePresence mode="sync">
+              <AnimatePresence mode="popLayout">
                 {state.items.map((item) => (
                   <BasketLineItem item={item} key={item.variantId} />
                 ))}


### PR DESCRIPTION
1. Smoothed layout animations when an item is deleted.
2. Introduced new vertical cut animation for the empty basket message when the last item is removed.

Previously, the layout shifting was inconsistent. The link to continue shopping would sometimes jump to and from its final position after an item was removed before performing the intended smooth translation.