### PR TITLE
feat: Add pickupSlot component to checkout form

### DIFF
--- a/backend/src/main/java/com/alex_lieu/hanok/enums/PickupSlot.java
+++ b/backend/src/main/java/com/alex_lieu/hanok/enums/PickupSlot.java
@@ -10,9 +10,9 @@ import java.util.Arrays;
 @Getter
 public enum PickupSlot {
     SLOT_1(new TimeRange("2:00PM - 3:00PM", LocalTime.of(14,0), LocalTime.of(15, 0))),
-    SLOT_2(new TimeRange("2:00PM - 3:00PM", LocalTime.of(15,0), LocalTime.of(16, 0))),
-    SLOT_3(new TimeRange("2:00PM - 3:00PM", LocalTime.of(16,0), LocalTime.of(17, 0))),
-    SLOT_4(new TimeRange("2:00PM - 3:00PM", LocalTime.of(17, 0), LocalTime.of(18, 0))),
+    SLOT_2(new TimeRange("3:00PM - 4:00PM", LocalTime.of(15, 0), LocalTime.of(16, 0))),
+    SLOT_3(new TimeRange("4:00PM - 5:00PM", LocalTime.of(16, 0), LocalTime.of(17, 0))),
+    SLOT_4(new TimeRange("5:00PM - 6:00PM", LocalTime.of(17, 0), LocalTime.of(18, 0))),
     ;
 
     private final TimeRange timeRange;

--- a/frontend/src/components/checkout/BillingAddressForm.tsx
+++ b/frontend/src/components/checkout/BillingAddressForm.tsx
@@ -6,10 +6,7 @@ import {
 } from "../../schemas/BillingAddressSchema";
 import { useEffect } from "react";
 import { Select, SelectItem } from "../ui/aria/Select";
-import { selectButtonStyles as defaultSelectButtonStyles } from "../ui/aria/styles/selectButtonStyles";
-import { inputStyles } from "../ui/aria/styles/inputStyles";
-import { tv } from "tailwind-variants";
-import { twMerge } from "tailwind-merge";
+import { borderedSelectButtonStyles } from "../ui/aria/styles/borderedSelectButtonStyles";
 import { TextField } from "../ui/aria/TextField";
 import { COUNTRY_CODES } from "../../schemas/BillingAddressSchema";
 import { useLoaderData } from "react-router-dom";
@@ -20,14 +17,6 @@ import {
 } from "../../utils/postalCodeUtils";
 import { checkIsCountry } from "../../utils/countryUtils";
 import { useServerErrors } from "../../utils/hooks/features/checkout/useServerErrors";
-
-const selectButtonStyles = tv({
-  extend: defaultSelectButtonStyles,
-  base: twMerge(
-    inputStyles.base,
-    "h-full focus:border-brand-colour-4 focus-visible:ring-[2px] focus-visible:ring-offset-default-bg focus-visible:ring-offset-[2px] focus-visible:transition-shadow focus-visible:ring-brand-focus"
-  ),
-});
 
 type FieldLabelConfig = {
   label: string;
@@ -103,7 +92,7 @@ const BillingAddressForm = () => {
             inputRef={ref}
             value={value}
             onChange={onChange}
-            buttonClassNames={selectButtonStyles}
+            buttonClassNames={borderedSelectButtonStyles}
             {...field}
           >
             {countryList.map(({ value, label }) => (
@@ -183,7 +172,7 @@ const BillingAddressForm = () => {
               inputRef={ref}
               value={value}
               onChange={onChange}
-              buttonClassNames={selectButtonStyles}
+              buttonClassNames={borderedSelectButtonStyles}
               {...field}
             >
               {config.options instanceof Set

--- a/frontend/src/components/checkout/BillingAddressForm.tsx
+++ b/frontend/src/components/checkout/BillingAddressForm.tsx
@@ -32,7 +32,7 @@ type CountryFieldSpecificConfig = {
 const countryFieldConfigs: Record<string, CountryFieldSpecificConfig> = {
   GB: {
     postalCode: { label: "Postcode" },
-    county: { label: "County (Optional)" },
+    county: { label: "County" },
   },
   US: {
     postalCode: { label: "ZIP Code" },
@@ -280,8 +280,8 @@ const BillingAddressForm = () => {
           const invalidState = !!(invalid || serverError);
           return (
             <TextField
-              label="Apartment, suite, etc. (optional)"
-              placeholder="Apartment, suite, etc. (optional)"
+              label="Apartment, suite, etc."
+              placeholder="Apartment, suite, etc."
               maxLength={30}
               inputRef={ref}
               isInvalid={invalidState}

--- a/frontend/src/components/checkout/CheckoutSession.tsx
+++ b/frontend/src/components/checkout/CheckoutSession.tsx
@@ -65,6 +65,7 @@ const DEFAULT_CARD_DETAILS: CardInformation = {
   holderName: "",
 };
 
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
 const DEFAULT_CHECKOUT_FORM_VALUES: CheckoutFormValues = {
   ...DEFAULT_CUSTOMER_DETAILS,
   ...DEFAULT_BILLING_ADDRESS,
@@ -79,7 +80,13 @@ export const CheckoutSession = ({ checkoutData }: CheckoutSessionProps) => {
   const navigate = useNavigate();
   const {
     basketContent: { items, total },
-    pickupRules: { firstValidDate, lastValidDate, unavailableDates },
+    pickupRules: {
+      firstValidDate,
+      lastValidDate,
+      unavailableDates,
+      pickupSlots,
+      openingHours,
+    },
     validStatesProvincesRegions,
   } = checkoutData;
 
@@ -87,13 +94,17 @@ export const CheckoutSession = ({ checkoutData }: CheckoutSessionProps) => {
     return createCheckoutSchema(
       unavailableDates,
       { start: firstValidDate, end: lastValidDate },
-      validStatesProvincesRegions
+      validStatesProvincesRegions,
+      pickupSlots,
+      openingHours
     );
   }, [
     firstValidDate,
     lastValidDate,
     unavailableDates,
     validStatesProvincesRegions,
+    pickupSlots,
+    openingHours,
   ]);
 
   const methods = useForm<CheckoutFormValues>({

--- a/frontend/src/components/checkout/CheckoutSession.tsx
+++ b/frontend/src/components/checkout/CheckoutSession.tsx
@@ -145,7 +145,7 @@ export const CheckoutSession = ({ checkoutData }: CheckoutSessionProps) => {
       phoneNumber: data.phoneNumber?.phoneNumber || undefined,
       specialInstructions: data.specialInstructions || undefined,
       pickupDate: data.pickupDate!.toString(),
-      pickupSlot: "SLOT_1", // TODO: Add pickup slot to the order request
+      pickupSlot: data.pickupSlot!,
       orderItems: items.map((item) => ({
         productVariantId: item.variantId,
         quantity: item.quantity,

--- a/frontend/src/components/checkout/CustomerForm.tsx
+++ b/frontend/src/components/checkout/CustomerForm.tsx
@@ -11,6 +11,7 @@ import { ControlledPhoneField } from "../ui/form/ControlledPhoneField";
 import { useCallback } from "react";
 import { CheckoutFormValues } from "../../schemas/CheckoutSchema";
 import { useServerErrors } from "../../utils/hooks/features/checkout/useServerErrors";
+import PickupSlotSelect from "../ui/form/PickupSlotSelect";
 
 const CustomerForm = () => {
   const {
@@ -162,6 +163,7 @@ const CustomerForm = () => {
             }}
           />
         </I18nProvider>
+        <PickupSlotSelect />
         <Controller
           name="updatePreference"
           control={control}

--- a/frontend/src/components/checkout/CustomerForm.tsx
+++ b/frontend/src/components/checkout/CustomerForm.tsx
@@ -131,39 +131,41 @@ const CustomerForm = () => {
         <legend className="lowercase tracking-wide text-lg font-medium mb-2">
           pickup and updates
         </legend>
-        <I18nProvider locale="en-GB">
-          <Controller
-            name="pickupDate"
-            control={control}
-            render={({
-              field: { onChange, onBlur, value, ref },
-              fieldState: { invalid, error },
-            }) => {
-              const zodError = error?.message;
-              const serverError =
-                serverErrors.validationErrors.pickupDate?.[0]?.message;
-              const errorMessage = zodError || serverError;
-              const invalidState = !!(invalid || serverError);
-              return (
-                <DatePicker
-                  isInvalid={invalidState}
-                  value={value}
-                  inputRef={ref}
-                  onChange={onChange}
-                  onBlur={onBlur}
-                  errorMessage={errorMessage}
-                  minValue={firstValidDate}
-                  maxValue={lastValidDate}
-                  isDateUnavailable={isDateUnavailable}
-                  unavailableDates={unavailableDates}
-                  isRequired
-                  label="What is your preferred pickup date?"
-                />
-              );
-            }}
-          />
-        </I18nProvider>
-        <PickupSlotSelect />
+        <div className="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-1 lg:grid-cols-2 gap-[0.7rem]">
+          <I18nProvider locale="en-GB">
+            <Controller
+              name="pickupDate"
+              control={control}
+              render={({
+                field: { onChange, onBlur, value, ref },
+                fieldState: { invalid, error },
+              }) => {
+                const zodError = error?.message;
+                const serverError =
+                  serverErrors.validationErrors.pickupDate?.[0]?.message;
+                const errorMessage = zodError || serverError;
+                const invalidState = !!(invalid || serverError);
+                return (
+                  <DatePicker
+                    isInvalid={invalidState}
+                    value={value}
+                    inputRef={ref}
+                    onChange={onChange}
+                    onBlur={onBlur}
+                    errorMessage={errorMessage}
+                    minValue={firstValidDate}
+                    maxValue={lastValidDate}
+                    isDateUnavailable={isDateUnavailable}
+                    unavailableDates={unavailableDates}
+                    isRequired
+                    label="Pickup Date"
+                  />
+                );
+              }}
+            />
+          </I18nProvider>
+          <PickupSlotSelect />
+        </div>
         <Controller
           name="updatePreference"
           control={control}

--- a/frontend/src/components/ui/aria/styles/borderedSelectButtonStyles.ts
+++ b/frontend/src/components/ui/aria/styles/borderedSelectButtonStyles.ts
@@ -1,0 +1,12 @@
+import { tv } from "tailwind-variants";
+import { twMerge } from "tailwind-merge";
+import { selectButtonStyles as defaultSelectButtonStyles } from "./selectButtonStyles";
+import { inputStyles } from "./inputStyles";
+
+export const borderedSelectButtonStyles = tv({
+  extend: defaultSelectButtonStyles,
+  base: twMerge(
+    inputStyles.base,
+    "h-full focus:border-brand-colour-4 focus-visible:ring-[2px] focus-visible:ring-offset-default-bg focus-visible:ring-offset-[2px] focus-visible:transition-shadow focus-visible:ring-brand-focus"
+  ),
+});

--- a/frontend/src/components/ui/form/PickupSlotSelect.tsx
+++ b/frontend/src/components/ui/form/PickupSlotSelect.tsx
@@ -1,0 +1,81 @@
+import { Controller, useFormContext, useWatch } from "react-hook-form";
+import { CheckoutFormValues } from "../../../schemas/CheckoutSchema";
+import { SelectItem } from "../aria/Select";
+import { Select } from "../aria/Select";
+import { useLoaderData } from "react-router-dom";
+import { CheckoutRequiredData } from "../../../types/CheckoutType";
+import { useServerErrors } from "../../../utils/hooks/features/checkout/useServerErrors";
+import { useMemo } from "react";
+import { DayOfWeek, getDayOfWeek } from "@internationalized/date";
+
+const PickupSlotSelect = () => {
+  const {
+    pickupRules: { pickupSlots, openingHours },
+  } = useLoaderData<CheckoutRequiredData>();
+  const serverErrors = useServerErrors();
+  const { control } = useFormContext<CheckoutFormValues>();
+  const selectedPickupDate = useWatch({ control, name: "pickupDate" });
+
+  const openingHoursMap = useMemo(() => {
+    return new Map(
+      openingHours.map((hour) => [
+        hour.dayOfWeek,
+        { start: hour.start, end: hour.end },
+      ])
+    );
+  }, [openingHours]);
+
+  const selectedDayOpeningHours = selectedPickupDate
+    ? openingHoursMap.get(
+        getDayOfWeek(selectedPickupDate, "en-GB") as unknown as DayOfWeek
+      )
+    : undefined;
+  const availablePickupSlots = selectedDayOpeningHours
+    ? pickupSlots.filter(
+        (slot) =>
+          slot.end.compare(selectedDayOpeningHours.end) < 0 &&
+          slot.start.compare(selectedDayOpeningHours.start) > 0
+      )
+    : [];
+
+  return (
+    <div>
+      <Controller
+        name="pickupSlot"
+        control={control}
+        render={({
+          field: { onChange, onBlur, value, ref },
+          fieldState: { invalid, error },
+        }) => {
+          const zodError = error?.message;
+          const serverError =
+            serverErrors.validationErrors.pickupSlot?.[0]?.message;
+          const errorMessage = zodError || serverError;
+          const invalidState = !!(invalid || serverError);
+          return (
+            <Select
+              label="And your preferred pickup time?"
+              isRequired
+              isInvalid={invalidState}
+              errorMessage={errorMessage}
+              inputRef={ref}
+              onChange={onChange}
+              onBlur={onBlur}
+              value={value}
+            >
+              {availablePickupSlots.map(({ value, label }) => {
+                return (
+                  <SelectItem key={value} id={value}>
+                    {label}
+                  </SelectItem>
+                );
+              })}
+            </Select>
+          );
+        }}
+      />
+    </div>
+  );
+};
+
+export default PickupSlotSelect;

--- a/frontend/src/components/ui/form/PickupSlotSelect.tsx
+++ b/frontend/src/components/ui/form/PickupSlotSelect.tsx
@@ -55,7 +55,7 @@ const PickupSlotSelect = () => {
           const invalidState = !!(invalid || serverError);
           return (
             <Select
-              label="And your preferred pickup time?"
+              label="Pickup Time"
               buttonClassNames={borderedSelectButtonStyles}
               isRequired
               isInvalid={invalidState}

--- a/frontend/src/components/ui/form/PickupSlotSelect.tsx
+++ b/frontend/src/components/ui/form/PickupSlotSelect.tsx
@@ -7,6 +7,7 @@ import { CheckoutRequiredData } from "../../../types/CheckoutType";
 import { useServerErrors } from "../../../utils/hooks/features/checkout/useServerErrors";
 import { useMemo } from "react";
 import { DayOfWeek, getDayOfWeek } from "@internationalized/date";
+import { borderedSelectButtonStyles } from "../aria/styles/borderedSelectButtonStyles";
 
 const PickupSlotSelect = () => {
   const {
@@ -55,6 +56,7 @@ const PickupSlotSelect = () => {
           return (
             <Select
               label="And your preferred pickup time?"
+              buttonClassNames={borderedSelectButtonStyles}
               isRequired
               isInvalid={invalidState}
               errorMessage={errorMessage}

--- a/frontend/src/constants/testData.ts
+++ b/frontend/src/constants/testData.ts
@@ -13,6 +13,7 @@ export const TEST_CUSTOMER_DETAILS = {
   phoneNumber: { countryCode: DEFAULT_COUNTRY_CODE, phoneNumber: "" },
   updatePreference: ["email"],
   pickupDate: new CalendarDate(2025, 12, 10),
+  pickupSlot: "SLOT_1",
   specialInstructions: "",
   paymentMethod: "card" as PaymentMethod,
 };

--- a/frontend/src/schemas/CheckoutSchema.ts
+++ b/frontend/src/schemas/CheckoutSchema.ts
@@ -4,15 +4,21 @@ import createCustomerFormSchema from "./CustomerFormSchema";
 import { createPaymentFormSchema } from "./PaymentFormSchema";
 import { ValidStatesProvincesRegions } from "../types/ValidStatesProvincesRegions";
 import { DateRange } from "../types/DateTypes";
+import { OpeningHour } from "../types/ConfigTypes";
+import { PickupSlot } from "../types/ConfigTypes";
 
 export const createCheckoutSchema = (
   unavailableDates: DateRange[],
   validDateRange: DateRange,
-  validStatesProvincesRegions: ValidStatesProvincesRegions
+  validStatesProvincesRegions: ValidStatesProvincesRegions,
+  pickupSlots: PickupSlot[],
+  openingHours: OpeningHour[]
 ) => {
   const customerSchema = createCustomerFormSchema(
     unavailableDates,
-    validDateRange
+    validDateRange,
+    pickupSlots,
+    openingHours
   );
   const { conditional: conditionalPaymentSchema } = createPaymentFormSchema(
     validStatesProvincesRegions

--- a/frontend/src/schemas/CustomerFormSchema.ts
+++ b/frontend/src/schemas/CustomerFormSchema.ts
@@ -65,57 +65,68 @@ const CustomerFormSchema = z
       .enum(PAYMENT_METHODS.map((method) => method.value))
       .default("card"),
   })
-  .superRefine(({ pickupDate, email, phoneNumber, updatePreference }, ctx) => {
-    if (!pickupDate) {
-      ctx.addIssue({
-        code: "custom",
-        message: "Please enter a valid date.",
-        path: ["pickupDate"],
-      });
-    }
+  .superRefine(
+    ({ pickupDate, pickupSlot, email, phoneNumber, updatePreference }, ctx) => {
+      if (!pickupDate) {
+        ctx.addIssue({
+          code: "custom",
+          message: "Please enter a valid date.",
+          path: ["pickupDate"],
+        });
+      }
 
-    const hasEmail = email && email.trim().length !== 0;
-    const hasPhoneNumber =
-      phoneNumber?.phoneNumber && phoneNumber?.phoneNumber.trim().length !== 0;
+      if (!pickupSlot) {
+        ctx.addIssue({
+          code: "custom",
+          message: "Please select a pickup slot.",
+          path: ["pickupSlot"],
+        });
+      }
 
-    if (!hasEmail && !hasPhoneNumber) {
-      ctx.addIssue({
-        code: "custom",
-        message: "Please provide either your email or phone number.",
-        path: ["contact"],
-      });
-    }
+      const hasEmail = email && email.trim().length !== 0;
+      const hasPhoneNumber =
+        phoneNumber?.phoneNumber &&
+        phoneNumber?.phoneNumber.trim().length !== 0;
 
-    if (
-      updatePreference?.includes("email") &&
-      !hasEmail &&
-      updatePreference?.includes("sms") &&
-      !hasPhoneNumber
-    ) {
-      ctx.addIssue({
-        code: "custom",
-        message:
-          "Please provide an email and a phone number to receive both email and SMS updates.",
-        path: ["updatePreference"],
-      });
-    }
+      if (!hasEmail && !hasPhoneNumber) {
+        ctx.addIssue({
+          code: "custom",
+          message: "Please provide either your email or phone number.",
+          path: ["contact"],
+        });
+      }
 
-    if (updatePreference?.includes("email") && !hasEmail) {
-      ctx.addIssue({
-        code: "custom",
-        message: "Please provide an email to receive email updates.",
-        path: ["updatePreference"],
-      });
-    }
+      if (
+        updatePreference?.includes("email") &&
+        !hasEmail &&
+        updatePreference?.includes("sms") &&
+        !hasPhoneNumber
+      ) {
+        ctx.addIssue({
+          code: "custom",
+          message:
+            "Please provide an email and a phone number to receive both email and SMS updates.",
+          path: ["updatePreference"],
+        });
+      }
 
-    if (updatePreference?.includes("sms") && !hasPhoneNumber) {
-      ctx.addIssue({
-        code: "custom",
-        message: "Please provide a phone number to receive SMS updates.",
-        path: ["updatePreference"],
-      });
+      if (updatePreference?.includes("email") && !hasEmail) {
+        ctx.addIssue({
+          code: "custom",
+          message: "Please provide an email to receive email updates.",
+          path: ["updatePreference"],
+        });
+      }
+
+      if (updatePreference?.includes("sms") && !hasPhoneNumber) {
+        ctx.addIssue({
+          code: "custom",
+          message: "Please provide a phone number to receive SMS updates.",
+          path: ["updatePreference"],
+        });
+      }
     }
-  });
+  );
 
 const createCustomerFormSchema = (
   unavailableDates: DateRange[],
@@ -149,14 +160,7 @@ const createCustomerFormSchema = (
         });
       }
     }
-    if (!pickupSlot) {
-      ctx.addIssue({
-        code: "custom",
-        message: "Please select a pickup slot.",
-        path: ["pickupSlot"],
-      });
-    }
-    if (!pickupSlots.some((slot) => slot.value === pickupSlot)) {
+    if (pickupSlot && !pickupSlots.some((slot) => slot.value === pickupSlot)) {
       ctx.addIssue({
         code: "custom",
         message: "Please select a valid pickup slot.",
@@ -175,6 +179,15 @@ const createCustomerFormSchema = (
             slot.start.compare(selectedDayOpeningHours.start) <= 0
         )
       : [];
+    if (pickupDate && pickupSlot && !selectedDayOpeningHours) {
+      ctx.addIssue({
+        code: "custom",
+        message:
+          "Sorry, we don't have opening hours for that day. Please choose another date.",
+        path: ["pickupSlot"],
+      });
+      return;
+    }
     if (unavailablePickupSlots.some((slot) => slot.value === pickupSlot)) {
       ctx.addIssue({
         code: "custom",

--- a/frontend/src/schemas/CustomerFormSchema.ts
+++ b/frontend/src/schemas/CustomerFormSchema.ts
@@ -1,8 +1,9 @@
 import { z } from "zod/v4";
-import { CalendarDate } from "@internationalized/date";
+import { CalendarDate, DayOfWeek, getDayOfWeek } from "@internationalized/date";
 import { PhoneSchema } from "./PhoneSchema";
 import { isDateInRanges } from "../utils/dateUtils";
 import { DateRange } from "../types/DateTypes";
+import { OpeningHour, PickupSlot } from "../types/ConfigTypes";
 
 export const PAYMENT_METHODS = [
   {
@@ -48,6 +49,7 @@ const CustomerFormSchema = z
     pickupDate: z
       .instanceof(CalendarDate, { message: "Please enter a valid date." })
       .nullish(),
+    pickupSlot: z.string().nullish(),
     updatePreference: z.optional(
       z
         .array(z.enum(["sms", "email"]))
@@ -117,9 +119,17 @@ const CustomerFormSchema = z
 
 const createCustomerFormSchema = (
   unavailableDates: DateRange[],
-  validDateRange: DateRange
+  validDateRange: DateRange,
+  pickupSlots: PickupSlot[],
+  openingHours: OpeningHour[]
 ) => {
-  return CustomerFormSchema.superRefine(({ pickupDate }, ctx) => {
+  const openingHoursMap = new Map(
+    openingHours.map((hour) => [
+      hour.dayOfWeek,
+      { start: hour.start, end: hour.end },
+    ])
+  );
+  return CustomerFormSchema.superRefine(({ pickupDate, pickupSlot }, ctx) => {
     if (pickupDate) {
       if (isDateInRanges(pickupDate, unavailableDates)) {
         ctx.addIssue({
@@ -138,6 +148,39 @@ const createCustomerFormSchema = (
           path: ["pickupDate"],
         });
       }
+    }
+    if (!pickupSlot) {
+      ctx.addIssue({
+        code: "custom",
+        message: "Please select a pickup slot.",
+        path: ["pickupSlot"],
+      });
+    }
+    if (!pickupSlots.some((slot) => slot.value === pickupSlot)) {
+      ctx.addIssue({
+        code: "custom",
+        message: "Please select a valid pickup slot.",
+        path: ["pickupSlot"],
+      });
+    }
+    const selectedDayOpeningHours = pickupDate
+      ? openingHoursMap.get(
+          getDayOfWeek(pickupDate, "en-GB") as unknown as DayOfWeek
+        )
+      : undefined;
+    const unavailablePickupSlots = selectedDayOpeningHours
+      ? pickupSlots.filter(
+          (slot) =>
+            slot.end.compare(selectedDayOpeningHours.end) >= 0 ||
+            slot.start.compare(selectedDayOpeningHours.start) <= 0
+        )
+      : [];
+    if (unavailablePickupSlots.some((slot) => slot.value === pickupSlot)) {
+      ctx.addIssue({
+        code: "custom",
+        message: "Please select a valid pickup slot.",
+        path: ["pickupSlot"],
+      });
     }
   });
 };

--- a/frontend/src/types/ConfigTypes.ts
+++ b/frontend/src/types/ConfigTypes.ts
@@ -1,4 +1,9 @@
-import { CalendarDate, ZonedDateTime } from "@internationalized/date";
+import {
+  CalendarDate,
+  DayOfWeek,
+  Time,
+  ZonedDateTime,
+} from "@internationalized/date";
 import { DateRange } from "./DateTypes";
 
 export interface ConfiguredPickupRules {
@@ -6,6 +11,11 @@ export interface ConfiguredPickupRules {
   lastValidDate: CalendarDate;
   unavailableDates: DateRange[];
   receivedAt: ZonedDateTime;
+  pickupSlots: { value: string; label: string; start: Time; end: Time }[];
+  openingHours: {
+    dayOfWeek: DayOfWeek;
+    timeRange: { label: string; start: Time; end: Time };
+  }[];
 }
 
 export type PickupRulesResponse = {
@@ -17,4 +27,9 @@ export type PickupRulesResponse = {
   holidayRanges: { start: string; end: string }[];
   firstValidDate: string;
   lastValidDate: string;
+  pickupSlots: { value: string; label: string; start: string; end: string }[];
+  openingHours: {
+    dayOfWeek: string;
+    timeRange: { label: string; start: string; end: string };
+  }[];
 };

--- a/frontend/src/types/ConfigTypes.ts
+++ b/frontend/src/types/ConfigTypes.ts
@@ -6,16 +6,27 @@ import {
 } from "@internationalized/date";
 import { DateRange } from "./DateTypes";
 
+export interface PickupSlot {
+  value: string;
+  label: string;
+  start: Time;
+  end: Time;
+}
+
+export interface OpeningHour {
+  dayOfWeek: DayOfWeek;
+  label: string;
+  start: Time;
+  end: Time;
+}
+
 export interface ConfiguredPickupRules {
   firstValidDate: CalendarDate;
   lastValidDate: CalendarDate;
   unavailableDates: DateRange[];
   receivedAt: ZonedDateTime;
-  pickupSlots: { value: string; label: string; start: Time; end: Time }[];
-  openingHours: {
-    dayOfWeek: DayOfWeek;
-    timeRange: { label: string; start: Time; end: Time };
-  }[];
+  pickupSlots: PickupSlot[];
+  openingHours: OpeningHour[];
 }
 
 export type PickupRulesResponse = {

--- a/frontend/src/utils/api/checkoutApi.ts
+++ b/frontend/src/utils/api/checkoutApi.ts
@@ -1,9 +1,38 @@
-import { now, parseDate } from "@internationalized/date";
+import { DayOfWeek, now, parseDate, parseTime } from "@internationalized/date";
 import {
   ConfiguredPickupRules,
   PickupRulesResponse,
 } from "../../types/ConfigTypes";
 import { ValidStatesProvincesRegions } from "../../types/ValidStatesProvincesRegions";
+
+/**
+ * Converts Java's DayOfWeek enum string (e.g., "MONDAY", "TUESDAY") to
+ * @internationalized/date DayOfWeek numeric value (0-6, where 0=Sunday, 1=Monday, etc.)
+ */
+function parseDayOfWeek(javaDayOfWeek: string): DayOfWeek {
+  const dayMap: Record<string, number> = {
+    MONDAY: 1,
+    TUESDAY: 2,
+    WEDNESDAY: 3,
+    THURSDAY: 4,
+    FRIDAY: 5,
+    SATURDAY: 6,
+    SUNDAY: 0, // Java uses 7, but @internationalized/date uses 0 for Sunday
+  };
+
+  const normalizedDay = javaDayOfWeek.trim().toUpperCase();
+  const dayOfWeek = dayMap[normalizedDay];
+
+  if (dayOfWeek === undefined) {
+    throw new Error(
+      `Invalid day of week: ${javaDayOfWeek}. Expected one of: ${Object.keys(
+        dayMap
+      ).join(", ")}`
+    );
+  }
+
+  return dayOfWeek as unknown as DayOfWeek;
+}
 
 export const getPickupRules = async (): Promise<ConfiguredPickupRules> => {
   try {
@@ -16,7 +45,30 @@ export const getPickupRules = async (): Promise<ConfiguredPickupRules> => {
       );
     }
     const data = (await response.json()) as PickupRulesResponse;
-    const { timezone, holidayRanges, firstValidDate, lastValidDate } = data;
+    const {
+      timezone,
+      holidayRanges,
+      firstValidDate,
+      lastValidDate,
+      pickupSlots: rawPickupSlots,
+      openingHours: rawOpeningHours,
+    } = data;
+
+    const pickupSlots = rawPickupSlots.map((slot) => ({
+      value: slot.value,
+      label: slot.label,
+      start: parseTime(slot.start),
+      end: parseTime(slot.end),
+    }));
+
+    const openingHours = rawOpeningHours.map((hour) => ({
+      dayOfWeek: parseDayOfWeek(hour.dayOfWeek),
+      timeRange: {
+        label: hour.timeRange.label,
+        start: parseTime(hour.timeRange.start),
+        end: parseTime(hour.timeRange.end),
+      },
+    }));
 
     const unavailableDates = holidayRanges.map((range) => ({
       start: parseDate(range.start),
@@ -28,6 +80,8 @@ export const getPickupRules = async (): Promise<ConfiguredPickupRules> => {
       lastValidDate: parseDate(lastValidDate),
       unavailableDates,
       receivedAt: now(timezone),
+      pickupSlots,
+      openingHours,
     } as ConfiguredPickupRules;
   } catch (error) {
     console.log("Failed to fetch pickup rules: ", error);

--- a/frontend/src/utils/api/checkoutApi.ts
+++ b/frontend/src/utils/api/checkoutApi.ts
@@ -7,17 +7,17 @@ import { ValidStatesProvincesRegions } from "../../types/ValidStatesProvincesReg
 
 /**
  * Converts Java's DayOfWeek enum string (e.g., "MONDAY", "TUESDAY") to
- * @internationalized/date DayOfWeek numeric value (0-6, where 0=Sunday, 1=Monday, etc.)
+ * @internationalized/date DayOfWeek numeric value with locale "en-GB" (0-6, where 6=Sunday, 0=Monday, etc.)
  */
 function parseDayOfWeek(javaDayOfWeek: string): DayOfWeek {
   const dayMap: Record<string, number> = {
-    MONDAY: 1,
-    TUESDAY: 2,
-    WEDNESDAY: 3,
-    THURSDAY: 4,
-    FRIDAY: 5,
-    SATURDAY: 6,
-    SUNDAY: 0, // Java uses 7, but @internationalized/date uses 0 for Sunday
+    MONDAY: 0,
+    TUESDAY: 1,
+    WEDNESDAY: 2,
+    THURSDAY: 3,
+    FRIDAY: 4,
+    SATURDAY: 5,
+    SUNDAY: 6,
   };
 
   const normalizedDay = javaDayOfWeek.trim().toUpperCase();
@@ -63,11 +63,9 @@ export const getPickupRules = async (): Promise<ConfiguredPickupRules> => {
 
     const openingHours = rawOpeningHours.map((hour) => ({
       dayOfWeek: parseDayOfWeek(hour.dayOfWeek),
-      timeRange: {
-        label: hour.timeRange.label,
-        start: parseTime(hour.timeRange.start),
-        end: parseTime(hour.timeRange.end),
-      },
+      label: hour.timeRange.label,
+      start: parseTime(hour.timeRange.start),
+      end: parseTime(hour.timeRange.end),
     }));
 
     const unavailableDates = holidayRanges.map((range) => ({

--- a/frontend/src/utils/loader.ts
+++ b/frontend/src/utils/loader.ts
@@ -110,6 +110,8 @@ export const checkoutLoader = async (): Promise<CheckoutRequiredData> => {
         isHoliday: () => false,
         receivedAt: now(getLocalTimeZone()),
         unavailableDates: [],
+        pickupSlots: [],
+        openingHours: [],
       } as ConfiguredPickupRules,
       basketContent: { items: [], total: 0 } as BasketResponse,
       validStatesProvincesRegions: {


### PR DESCRIPTION
## Overview
This PR introduces a select field for pickupSlot selection that is validated along with all other fields in the checkout form using the **CheckoutSchema**.

### Pickup Slot Component
- The **pickupSlot** field is separated as its own component to prevent unnecessary re-renders when the **pickupDate** value changes (via the useWatch hook) which it needs to correctly display the available slots
- The component is built using a Select component and is populated using data (slots, opening hours) from the checkout loader
- The selectable slot values are dependent on which slot values fall within the opening hours of the selected pickupDate
    - TODO: Disable the slot field when the pickupDate selected is invalid

### Validation
- Slot must be a valid value - SLOT_1 through SLOT_4 as defined by the pickup rules API
- Slot must fall within the opening hours of the selected pickup day
- If opening hours are missing for a date then validation fails
- The field displays server errors using the useServerError hook