### PR TITLE
feat: Introduce debounced trigger validations on the email and phone number fields

### DIFF
--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -47,6 +47,7 @@
     --color-brand-colour-5: #6B8083;
     --color-unavailable: #DBD9DA;
     --color-unavailable-text: #59585D;
+    --color-disabled-text: #b2b2b2;
     --color-tooltip-bg: #181527; /* Not using at the moment */
     --color-icon-disabled: #B6C2C4;
     --color-icon-disabled-bg: #E7E9EC;

--- a/frontend/src/components/checkout/CustomerForm.tsx
+++ b/frontend/src/components/checkout/CustomerForm.tsx
@@ -136,19 +136,7 @@ const CustomerForm = () => {
             );
           }}
         />
-        <Controller
-          name="phoneNumber"
-          control={control}
-          render={({ field, fieldState }) => (
-            <ControlledPhoneField
-              formState={formState}
-              field={field}
-              fieldState={fieldState}
-              trigger={trigger}
-              hasContactError={!!errors.contact}
-            />
-          )}
-        />
+        <ControlledPhoneField />
       </fieldset>
       <fieldset className="space-y-[0.7rem]">
         <legend className="lowercase tracking-wide text-lg font-medium mb-2">

--- a/frontend/src/components/checkout/CustomerForm.tsx
+++ b/frontend/src/components/checkout/CustomerForm.tsx
@@ -98,16 +98,21 @@ const CustomerForm = () => {
                   setValue("email", val, {
                     shouldValidate: false,
                     shouldDirty: true,
-                    shouldTouch: true,
                   });
-                  const fieldsToValidate: (keyof CheckoutFormValues)[] = [
-                    "email",
-                    "contact",
-                  ];
-                  if (triggerUpdatePreferenceValidation) {
-                    fieldsToValidate.push("updatePreference");
+                  if (
+                    submitCount > 0 ||
+                    touchedFields.email ||
+                    touchedFields.phoneNumber
+                  ) {
+                    const fieldsToValidate: (keyof CheckoutFormValues)[] = [
+                      "email",
+                      "contact",
+                    ];
+                    if (triggerUpdatePreferenceValidation) {
+                      fieldsToValidate.push("updatePreference");
+                    }
+                    debouncedTrigger(fieldsToValidate);
                   }
-                  debouncedTrigger(fieldsToValidate);
                 }}
                 onBlur={() => {
                   onBlur();

--- a/frontend/src/components/checkout/CustomerForm.tsx
+++ b/frontend/src/components/checkout/CustomerForm.tsx
@@ -12,17 +12,21 @@ import { useCallback } from "react";
 import { CheckoutFormValues } from "../../schemas/CheckoutSchema";
 import { useServerErrors } from "../../utils/hooks/features/checkout/useServerErrors";
 import PickupSlotSelect from "../ui/form/PickupSlotSelect";
+import { useDebouncedFormTrigger } from "../../utils/hooks/features/checkout/useDebouncedFormTrigger";
 
 const CustomerForm = () => {
   const {
     pickupRules: { firstValidDate, lastValidDate, unavailableDates },
   } = useLoaderData() as CheckoutRequiredData;
 
-  const { control, trigger, formState } = useFormContext<CheckoutFormValues>();
+  const { control, trigger, formState, setValue } =
+    useFormContext<CheckoutFormValues>();
 
   const { errors, touchedFields, dirtyFields, submitCount } = formState;
 
   const serverErrors = useServerErrors();
+
+  const debouncedTrigger = useDebouncedFormTrigger();
 
   const isDateUnavailable = useCallback(
     (date: DateValue) => isDateInRanges(date, unavailableDates),
@@ -69,7 +73,7 @@ const CustomerForm = () => {
           name="email"
           control={control}
           render={({
-            field: { onChange, onBlur, value, ref },
+            field: { onBlur, value, ref },
             fieldState: { invalid, error },
           }) => {
             const zodError = error?.message;
@@ -78,20 +82,39 @@ const CustomerForm = () => {
             const contactError = errors.contact?.message;
             const errorMessage = zodError || serverError || contactError;
             const invalidState = !!(invalid || serverError || contactError);
+
+            const triggerUpdatePreferenceValidation: boolean = !!(
+              (touchedFields.email || dirtyFields.email) &&
+              (submitCount > 0 || dirtyFields.updatePreference)
+            );
+
             return (
               <TextField
                 inputRef={ref}
                 value={value}
-                onChange={(e) => {
-                  onChange(e);
-                  if (
-                    (touchedFields.email || dirtyFields.email) &&
-                    (submitCount > 0 || dirtyFields.updatePreference)
-                  )
-                    trigger("updatePreference");
-                  trigger("contact");
+                onChange={(val) => {
+                  // This is the key to bypass the validation mode enforced by RHF.
+                  // We set the value immediately, without validation, and then trigger the debounced validation.
+                  setValue("email", val, {
+                    shouldValidate: false,
+                    shouldDirty: true,
+                    shouldTouch: true,
+                  });
+                  const fieldsToValidate: (keyof CheckoutFormValues)[] = [
+                    "email",
+                    "contact",
+                  ];
+                  if (triggerUpdatePreferenceValidation) {
+                    fieldsToValidate.push("updatePreference");
+                  }
+                  debouncedTrigger(fieldsToValidate);
                 }}
-                onBlur={onBlur}
+                onBlur={() => {
+                  onBlur();
+                  if (triggerUpdatePreferenceValidation)
+                    trigger(["updatePreference"]);
+                  trigger(["email", "contact"]);
+                }}
                 label="Email"
                 tooltip={
                   <Tooltip

--- a/frontend/src/components/ui/aria/DateField.tsx
+++ b/frontend/src/components/ui/aria/DateField.tsx
@@ -77,7 +77,10 @@ export const DateInput = (props: DateInputProps) => {
       {...dateInputProps}
     >
       {(segment) => (
-        <DateSegment segment={segment} className={segmentStyles()} />
+        <DateSegment
+          segment={segment}
+          className={(renderProps) => segmentStyles({ ...renderProps })}
+        />
       )}
     </AriaDateInput>
   );

--- a/frontend/src/components/ui/aria/DateField.tsx
+++ b/frontend/src/components/ui/aria/DateField.tsx
@@ -49,7 +49,7 @@ const segmentStyles = tv({
       true: "text-gray-600 italic",
     },
     isDisabled: {
-      true: "text-gray-200",
+      true: "text-disabled-text",
     },
     isFocused: {
       true: "bg-brand-colour-2 text-default-bg outline-none",
@@ -76,7 +76,9 @@ export const DateInput = (props: DateInputProps) => {
       }
       {...dateInputProps}
     >
-      {(segment) => <DateSegment segment={segment} className={segmentStyles} />}
+      {(segment) => (
+        <DateSegment segment={segment} className={segmentStyles()} />
+      )}
     </AriaDateInput>
   );
 };

--- a/frontend/src/components/ui/aria/DatePicker.tsx
+++ b/frontend/src/components/ui/aria/DatePicker.tsx
@@ -64,13 +64,14 @@ export const DatePicker = memo(function DatePicker({
           className="flex-1 min-w-[150px] px-2 py-1.5 text-sm"
         />
         <Button variant="iconNoInteraction" className="mr-1 p-0">
-          {({ isHovered, isFocused }) => {
+          {({ isHovered, isFocused, isDisabled }) => {
             return (
               <CalendarDaysIcon
                 aria-hidden
                 size={"1.2rem"}
                 strokeWidth={2.3}
-                playAnimation={isHovered || isFocused}
+                isDisabled={isDisabled}
+                playAnimation={isDisabled ? false : isHovered || isFocused}
               />
             );
           }}

--- a/frontend/src/components/ui/aria/PhoneField.tsx
+++ b/frontend/src/components/ui/aria/PhoneField.tsx
@@ -14,6 +14,7 @@ import { composeTailwindRenderProps } from "./utils";
 import { RefCallBack } from "react-hook-form";
 import { createLabel } from "./utils/createLabel";
 import { CircleChevronDownIcon } from "../icons/CircleChevronDown";
+import { twMerge } from "tailwind-merge";
 
 function getCountryFromCode(code: CountryCodeUnion) {
   return countries.find((c) => c.code === code) || countries[0];
@@ -51,7 +52,7 @@ const buttonStyles = tv({
   base: "flex items-center text-start w-full cursor-default px-1 my-auto ml-1 py-1 focus:outline-none inset-ring-brand-focus",
   variants: {
     isDisabled: {
-      true: "bg-stone-300",
+      true: "opacity-30",
     },
     isFocusVisible: {
       false: "inset-ring-0",
@@ -78,6 +79,7 @@ export const PhoneField = memo(function PhoneField({
   errorMessage,
   inputRef,
   isInvalid,
+  isDisabled,
   phoneNumber,
   countryCode,
   onPhoneNumberChange,
@@ -101,7 +103,11 @@ export const PhoneField = memo(function PhoneField({
           size="0.9rem"
           fill="var(--color-default-bg)"
           strokeWidth={3}
-          stroke="var(--color-brand-colour-5)"
+          stroke={
+            isDisabled
+              ? "var(--color-disabled-text)"
+              : "var(--color-brand-colour-5)"
+          }
           playAnimation={playAnimation}
         />
       </div>
@@ -115,6 +121,7 @@ export const PhoneField = memo(function PhoneField({
 
   return (
     <TextField
+      isDisabled={isDisabled}
       {...props}
       className={composeTailwindRenderProps(
         props.className,
@@ -143,6 +150,7 @@ export const PhoneField = memo(function PhoneField({
           customSelectValue={({ isHovered, isFocused }) =>
             getCountryFlag(isHovered || isFocused)
           }
+          isDisabled={isDisabled}
           defaultChevron={false}
           onFocusChange={setIsFocused}
           widePopover={true}
@@ -170,7 +178,10 @@ export const PhoneField = memo(function PhoneField({
           id={inputId}
           value={phoneNumber}
           inputRef={inputRef}
-          className="focus:outline-0 flex-1 text-sm"
+          className={twMerge(
+            "focus:outline-0 flex-1 text-sm",
+            isDisabled && "text-disabled-text"
+          )}
           placeholder={getCountryFromCode(countryCode).example}
           onChange={(e) =>
             onPhoneNumberChange(

--- a/frontend/src/components/ui/aria/Select.tsx
+++ b/frontend/src/components/ui/aria/Select.tsx
@@ -138,7 +138,7 @@ export function Select<T extends object>({
       <Button
         className={buttonClassNames ? buttonClassNames : selectButtonStyles}
       >
-        {({ isHovered, isFocused }) => (
+        {({ isHovered, isFocused, isDisabled }) => (
           <>
             <SelectValue className="flex-1 text-sm placeholder-shown:italic truncate">
               {({ defaultChildren, isPlaceholder }) => {
@@ -175,9 +175,13 @@ export function Select<T extends object>({
             </SelectValue>
             {defaultChevron ? (
               <LuChevronDown
-                stroke="var(--color-brand-colour-5)"
+                stroke={
+                  isDisabled
+                    ? "var(--color-unavailable)"
+                    : "var(--color-brand-colour-5)"
+                }
                 strokeWidth={3}
-                className="scale-115 group-disabled:text-gray-200"
+                className="scale-115"
               />
             ) : undefined}
           </>

--- a/frontend/src/components/ui/aria/styles/borderedSelectButtonStyles.ts
+++ b/frontend/src/components/ui/aria/styles/borderedSelectButtonStyles.ts
@@ -7,6 +7,9 @@ export const borderedSelectButtonStyles = tv({
   extend: defaultSelectButtonStyles,
   base: twMerge(
     inputStyles.base,
-    "h-full focus:border-brand-colour-4 focus-visible:ring-[2px] focus-visible:ring-offset-default-bg focus-visible:ring-offset-[2px] focus-visible:transition-shadow focus-visible:ring-brand-focus"
+    "h-fit focus:border-brand-colour-4 focus-visible:ring-[2px] focus-visible:ring-offset-default-bg focus-visible:ring-offset-[2px] focus-visible:transition-shadow focus-visible:ring-brand-focus"
   ),
+  variants: {
+    isDisabled: { true: "border-unavailable" },
+  },
 });

--- a/frontend/src/components/ui/aria/styles/fieldBorderStyles.tsx
+++ b/frontend/src/components/ui/aria/styles/fieldBorderStyles.tsx
@@ -10,7 +10,7 @@ export const fieldBorderStyles = tv({
       true: "border-error-red",
     },
     isDisabled: {
-      true: "bg-unavailable",
+      true: "border-unavailable text-disabled-text",
     },
   },
   compoundVariants: [

--- a/frontend/src/components/ui/aria/styles/selectButtonStyles.tsx
+++ b/frontend/src/components/ui/aria/styles/selectButtonStyles.tsx
@@ -5,7 +5,7 @@ export const selectButtonStyles = tv({
   variants: {
     isDisabled: {
       false: "text-gray-800 hover:bg-gray-100 group-invalid:border-error-red",
-      true: "text-gray-200",
+      true: "text-disabled-text",
     },
     isFocused: {
       true: "", // "ring-[2px] ring-brand-focus outline-none transition-shadow",

--- a/frontend/src/components/ui/form/ControlledPhoneField.tsx
+++ b/frontend/src/components/ui/form/ControlledPhoneField.tsx
@@ -43,17 +43,22 @@ export const ControlledPhoneField = memo(() => {
             {
               shouldValidate: false,
               shouldDirty: true,
-              shouldTouch: true,
             }
           );
-          const fieldsToValidate: (keyof CheckoutFormValues)[] = [
-            "phoneNumber",
-            "contact",
-          ];
-          if (triggerUpdatePreferenceValidation) {
-            fieldsToValidate.push("updatePreference");
+          if (
+            submitCount > 0 ||
+            touchedFields.phoneNumber ||
+            touchedFields.email
+          ) {
+            const fieldsToValidate: (keyof CheckoutFormValues)[] = [
+              "phoneNumber",
+              "contact",
+            ];
+            if (triggerUpdatePreferenceValidation) {
+              fieldsToValidate.push("updatePreference");
+            }
+            debouncedTrigger(fieldsToValidate);
           }
-          debouncedTrigger(fieldsToValidate);
         };
         const invalidState = !!(invalid || contactError || serverError);
         return (

--- a/frontend/src/components/ui/form/ControlledPhoneField.tsx
+++ b/frontend/src/components/ui/form/ControlledPhoneField.tsx
@@ -1,72 +1,80 @@
-import { memo, useCallback } from "react";
-import {
-  ControllerFieldState,
-  ControllerRenderProps,
-  FormState,
-  UseFormTrigger,
-} from "react-hook-form";
+import { memo } from "react";
+import { Controller, useFormContext } from "react-hook-form";
 import { PhoneField } from "../aria/PhoneField";
 import { DEFAULT_COUNTRY_CODE } from "../../../schemas/BillingAddressSchema";
 import { CountryCodeUnion } from "../../../schemas/PhoneSchema";
 import { CheckoutFormValues } from "../../../schemas/CheckoutSchema";
 import { useServerErrors } from "../../../utils/hooks/features/checkout/useServerErrors";
+import { useDebouncedFormTrigger } from "../../../utils/hooks/features/checkout/useDebouncedFormTrigger";
 
-interface ControlledPhoneFieldProps {
-  formState: FormState<CheckoutFormValues>;
-  field: ControllerRenderProps<CheckoutFormValues, "phoneNumber">;
-  fieldState: ControllerFieldState;
-  trigger: UseFormTrigger<CheckoutFormValues>;
-  hasContactError: boolean;
-}
+export const ControlledPhoneField = memo(() => {
+  const { control, trigger, formState, setValue } =
+    useFormContext<CheckoutFormValues>();
+  const { errors, touchedFields, dirtyFields, submitCount } = formState;
+  const debouncedTrigger = useDebouncedFormTrigger();
+  const { validationErrors } = useServerErrors();
+  const triggerUpdatePreferenceValidation: boolean = !!(
+    (touchedFields.phoneNumber || dirtyFields.phoneNumber) &&
+    (submitCount > 0 || dirtyFields.updatePreference)
+  );
 
-export const ControlledPhoneField = memo(
-  ({
-    formState: { errors, touchedFields, dirtyFields, submitCount },
-    field,
-    fieldState,
-    trigger,
-    hasContactError: contactError,
-  }: ControlledPhoneFieldProps) => {
-    const { onChange, onBlur, value, ref } = field;
-    const { invalid } = fieldState;
+  const contactError = errors.contact?.message;
+  const serverError = validationErrors.phoneNumber?.[0]?.message;
+  const errorMessage = errors?.phoneNumber?.phoneNumber?.message || serverError;
 
-    const handleCountryCodeChange = useCallback(
-      (newCountryCode: CountryCodeUnion) => {
-        onChange({ phoneNumber: "", countryCode: newCountryCode });
-      },
-      [onChange]
-    );
-
-    const handlePhoneNumberChange = useCallback(
-      (newPhoneNumber: string) => {
-        onChange({ ...value, phoneNumber: newPhoneNumber });
-        if (
-          (touchedFields.phoneNumber || dirtyFields.phoneNumber) &&
-          (submitCount > 0 || dirtyFields.updatePreference)
-        )
-          trigger("updatePreference");
-        trigger("contact");
-      },
-      [onChange, value, touchedFields, dirtyFields, submitCount, trigger]
-    );
-
-    const serverErrors = useServerErrors();
-    const serverError = serverErrors.phoneNumber?.[0]?.message;
-    const errorMessage =
-      errors?.phoneNumber?.phoneNumber?.message || serverError;
-    const invalidState = !!(invalid || contactError || serverError);
-    return (
-      <PhoneField
-        label="Phone Number"
-        isInvalid={invalidState}
-        errorMessage={errorMessage}
-        onBlur={onBlur}
-        inputRef={ref}
-        phoneNumber={value?.phoneNumber}
-        countryCode={value?.countryCode || DEFAULT_COUNTRY_CODE}
-        onCountryCodeChange={handleCountryCodeChange}
-        onPhoneNumberChange={handlePhoneNumberChange}
-      />
-    );
-  }
-);
+  return (
+    <Controller
+      name="phoneNumber"
+      control={control}
+      render={({
+        field: { onChange, onBlur, value, ref },
+        fieldState: { invalid },
+      }) => {
+        const handleCountryCodeChange = (newCountryCode: CountryCodeUnion) => {
+          onChange({ phoneNumber: "", countryCode: newCountryCode });
+        };
+        const handlePhoneNumberChange = (newPhoneNumber: string) => {
+          setValue(
+            "phoneNumber",
+            {
+              phoneNumber: newPhoneNumber,
+              countryCode: value?.countryCode || DEFAULT_COUNTRY_CODE,
+            },
+            {
+              shouldValidate: false,
+              shouldDirty: true,
+              shouldTouch: true,
+            }
+          );
+          const fieldsToValidate: (keyof CheckoutFormValues)[] = [
+            "phoneNumber",
+            "contact",
+          ];
+          if (triggerUpdatePreferenceValidation) {
+            fieldsToValidate.push("updatePreference");
+          }
+          debouncedTrigger(fieldsToValidate);
+        };
+        const invalidState = !!(invalid || contactError || serverError);
+        return (
+          <PhoneField
+            label="Phone Number"
+            isInvalid={invalidState}
+            errorMessage={errorMessage}
+            onBlur={() => {
+              onBlur();
+              if (triggerUpdatePreferenceValidation)
+                trigger(["updatePreference"]);
+              trigger(["phoneNumber", "contact"]);
+            }}
+            inputRef={ref}
+            phoneNumber={value?.phoneNumber}
+            countryCode={value?.countryCode || DEFAULT_COUNTRY_CODE}
+            onCountryCodeChange={handleCountryCodeChange}
+            onPhoneNumberChange={handlePhoneNumberChange}
+          />
+        );
+      }}
+    />
+  );
+});

--- a/frontend/src/components/ui/form/PickupSlotSelect.tsx
+++ b/frontend/src/components/ui/form/PickupSlotSelect.tsx
@@ -47,25 +47,28 @@ const PickupSlotSelect = () => {
         render={({
           field: { onChange, onBlur, value, ref },
           fieldState: { invalid, error },
+          formState: { errors },
         }) => {
           const zodError = error?.message;
           const serverError =
             serverErrors.validationErrors.pickupSlot?.[0]?.message;
           const errorMessage = zodError || serverError;
           const invalidState = !!(invalid || serverError);
+          const slotOptions = errors.pickupDate ? [] : availablePickupSlots;
           return (
             <Select
               label="Pickup Time"
               buttonClassNames={borderedSelectButtonStyles}
               isRequired
               isInvalid={invalidState}
+              isDisabled={!!errors.pickupDate}
               errorMessage={errorMessage}
               inputRef={ref}
               onChange={onChange}
               onBlur={onBlur}
               value={value}
             >
-              {availablePickupSlots.map(({ value, label }) => {
+              {slotOptions.map(({ value, label }) => {
                 return (
                   <SelectItem key={value} id={value}>
                     {label}

--- a/frontend/src/components/ui/icons/CalendarDays.tsx
+++ b/frontend/src/components/ui/icons/CalendarDays.tsx
@@ -6,6 +6,7 @@ export interface CalendarDaysIconProps extends HTMLAttributes<HTMLDivElement> {
   size?: string | number;
   strokeWidth?: number;
   playAnimation?: boolean | null;
+  isDisabled?: boolean;
 }
 
 const DOTS = [
@@ -23,6 +24,7 @@ const dotVariants: Variants = {
     opacity: [1, 0.3, 1],
     transition: { delay: i * 0.1, duration: 0.4, times: [0, 0.5, 1] },
   }),
+  disabled: { opacity: 1, transition: { duration: 0.2 } },
 };
 
 const svgVariants: Variants = {
@@ -37,6 +39,12 @@ const svgVariants: Variants = {
     color: "var(--color-brand-colour-2)",
     transition: { duration: 0.4, times: [0, 0.5, 1] },
   },
+  disabled: {
+    rotateZ: 0,
+    y: 0,
+    color: "var(--color-disabled-text)",
+    opacity: 0.6,
+  },
 };
 
 export const CalendarDaysIcon = ({
@@ -46,6 +54,7 @@ export const CalendarDaysIcon = ({
   playAnimation = null,
   onMouseEnter,
   onMouseLeave,
+  isDisabled = false,
   ...props
 }: CalendarDaysIconProps) => {
   const [isAnimationConditionMet, setIsAnimationConditionMet] = useState(false);
@@ -55,18 +64,22 @@ export const CalendarDaysIcon = ({
 
   const handleMouseEnter = useCallback(
     (e: MouseEvent<HTMLDivElement>) => {
-      setIsAnimationConditionMet(true);
-      onMouseEnter?.(e);
+      if (!isDisabled) {
+        setIsAnimationConditionMet(true);
+        onMouseEnter?.(e);
+      }
     },
-    [onMouseEnter]
+    [onMouseEnter, isDisabled]
   );
 
   const handleMouseLeave = useCallback(
     (e: MouseEvent<HTMLDivElement>) => {
-      setIsAnimationConditionMet(false);
-      onMouseLeave?.(e);
+      if (!isDisabled) {
+        setIsAnimationConditionMet(false);
+        onMouseLeave?.(e);
+      }
     },
-    [onMouseLeave]
+    [onMouseLeave, isDisabled]
   );
 
   return (
@@ -88,7 +101,7 @@ export const CalendarDaysIcon = ({
         strokeLinejoin="round"
         initial="normal"
         variants={svgVariants}
-        animate={shouldAnimate ? "animate" : "normal"}
+        animate={isDisabled ? "disabled" : shouldAnimate ? "animate" : "normal"}
       >
         <path d="M8 2v4" />
         <path d="M16 2v4" />
@@ -105,7 +118,9 @@ export const CalendarDaysIcon = ({
               stroke="none"
               initial="normal"
               variants={dotVariants}
-              animate={shouldAnimate ? "animate" : "normal"}
+              animate={
+                isDisabled ? "disabled" : shouldAnimate ? "animate" : "normal"
+              }
               custom={index}
             />
           ))}

--- a/frontend/src/utils/debounce.ts
+++ b/frontend/src/utils/debounce.ts
@@ -1,0 +1,24 @@
+/**
+ * Creates a debounce function that delays the calling of a function until after a delay.
+ *
+ * @param func - The function to debounce.
+ * @param delay - The delay in milliseconds.
+ * @returns A debounced function that will call the original function after the delay.
+ */
+// Note: `any[]` is necessary here for the the generic function constraint.
+// TS doesn't have a built-in type that means "any function signature", and unknown[] and
+// never[] are too restrictive.
+// The any[] is only in the constraint, not in the implementation. The actual parameter
+// types are preserved through Parameters<T>, so type safety is maintained at the call site.
+
+//  eslint-disable-next-line @typescript-eslint/no-explicit-any
+export function debounce<T extends (...args: any[]) => any>(
+  func: T,
+  delay: number
+): (...args: Parameters<T>) => void {
+  let timeoutId: ReturnType<typeof setTimeout>;
+  return function (...args: Parameters<T>) {
+    clearTimeout(timeoutId);
+    timeoutId = setTimeout(() => func(...args), delay);
+  };
+}

--- a/frontend/src/utils/hooks/features/checkout/useDebouncedFormTrigger.ts
+++ b/frontend/src/utils/hooks/features/checkout/useDebouncedFormTrigger.ts
@@ -3,7 +3,7 @@ import { CheckoutFormValues } from "../../../../schemas/CheckoutSchema";
 import { debounce } from "../../../debounce";
 import { useMemo } from "react";
 
-const DEBOUNCE_DELAY = 500;
+const DEBOUNCE_DELAY = 300;
 
 /**
  * Creates a debounced function that will trigger validation for the given field names after a delay.

--- a/frontend/src/utils/hooks/features/checkout/useDebouncedFormTrigger.ts
+++ b/frontend/src/utils/hooks/features/checkout/useDebouncedFormTrigger.ts
@@ -1,0 +1,25 @@
+import { useFormContext } from "react-hook-form";
+import { CheckoutFormValues } from "../../../../schemas/CheckoutSchema";
+import { debounce } from "../../../debounce";
+import { useMemo } from "react";
+
+const DEBOUNCE_DELAY = 500;
+
+/**
+ * Creates a debounced function that will trigger validation for the given field names after a delay.
+ *
+ * @returns A debounced function that will trigger the given field validations after a delay.
+ */
+export const useDebouncedFormTrigger = () => {
+  const { trigger } = useFormContext<CheckoutFormValues>();
+
+  const debouncedValidate = useMemo(
+    () =>
+      debounce((fieldNames: (keyof CheckoutFormValues)[]) => {
+        trigger(fieldNames);
+      }, DEBOUNCE_DELAY),
+    [trigger]
+  );
+
+  return debouncedValidate;
+};


### PR DESCRIPTION
## Overview
The biggest change in this PR is the update to the validation logic for the email and phone number fields to be debounced. This solves the sluggish typing in the fields by offsetting the validation to until after the user stops typing with a short delay. A smaller change is that the disabled state styling for the form fields - in the checkout form - are updated to use a lighter colour scheme to better distinguish the disabled state from the standard state.

### Debounce Validation
- Add a utility function (**debounce**) that returns a debounced function
- Add a hook (**useDebouncedFormTrigger**) that returns a function that triggers validation for the given form field names after a delay
- Update the email and phone number fields in the checkout form to debounce their validation triggers to reduce lag while typing
    - The debounce validation mode is triggered after the fields are first touched or after the first form submission to keep the validation logic more consistent with all the other fields in the form

### Disabled State Styling
- Introduce new tailwind colour variable (#b2b2b2) to represent disabled state text
- Update tailwind variants and their disabled state styles to better match and to utilise the new disabled state colours
- Update the disabled state stylings for the icons used in **PhoneField** and **DatePicker** by decreasing their opacity to enforce the disabled state to the user